### PR TITLE
Fixed annoying bug that caused '25D' to appear before DWORDS

### DIFF
--- a/ReClass/CNodeDword.cpp
+++ b/ReClass/CNodeDword.cpp
@@ -38,7 +38,7 @@ NODESIZE CNodeDword::Draw( const PVIEWINFO View, int x, int y )
     tx = AddText( View, tx, y, g_clrType, HS_NONE, _T( "DWORD " ) );
     tx = AddText( View, tx, y, g_clrName, HS_NAME, _T( "%s" ), m_strName );
     tx = AddText( View, tx, y, g_clrName, HS_NONE, _T( " = " ) );
-    tx = AddText( View, tx, y, g_clrValue, HS_EDIT, g_bUnsignedHex ? _T( "0x%IX" ) : _T( "%u" ), *Data ) + g_FontWidth;
+    tx = AddText( View, tx, y, g_clrValue, HS_EDIT, g_bUnsignedHex ? _T( "0x%X" ) : _T( "%u" ), *Data ) + g_FontWidth;
     tx = AddComment( View, tx, y );
 
     DrawSize.x = tx;


### PR DESCRIPTION
DWORDs used to look something like this (recreated):

![Screenshot - ReClassEx64 exe - 2019-06-20 00 09 18+ _ - N00000000 - 2APIam1CJOlLejH - 1003948](https://user-images.githubusercontent.com/4650770/59772872-eea2da80-92ef-11e9-9cd1-4dc87bedc849.png)

Fixed.